### PR TITLE
fix: use kebab-case in matching network with fa icon

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ handlebars.registerHelper({
   // formatAddress: (...args) => addressFormat(args).join(' '),
   formatAddress: (...args) => args.filter(arg => typeof arg !== 'object').join(' '),
   formatDate: date => moment(date).format('MM/YYYY'),
+  kebabcase: s => s.toLowerCase().replaceAll(/\s+/g, '-'),
   lowercase: s => s.toLowerCase(),
   eq: (a, b) => a === b,
 });

--- a/src/partials/social.hbs
+++ b/src/partials/social.hbs
@@ -5,7 +5,7 @@
         {{else if (eq (lowercase network) "portfolio")}}
             {{> info-tag text=this.username icon="fa-briefcase" }}
         {{else}}
-             {{> info-tag text=this.username icon=(concat "fa-" (lowercase network)) }}
+             {{> info-tag text=this.username icon=(concat "fa-" (kebabcase network)) }}
         {{/if}}
     {{/if}}
 {{/if}}


### PR DESCRIPTION
With this change we can use the official names containing whitespace for networks like `Stack Exchange`, `Stack Overflow` etc. and still automatically get the proper Font Awesome icon.

```json
{
  "basics": {
    "profiles": [
      {
        "network": "Stack Exchange",
        "username": "some-one",
        "url": "https://stackexchange.com/users/1234567/some-one"
      },
      {
        "network": "Stack Overflow",
        "username": "some-one",
        "url": "https://stackoverflow.com/users/1234567/some-one"
      }
    ]
  }
}
```